### PR TITLE
Fix constantly changing Role Assignments, circular dependency

### DIFF
--- a/modules/aks-cluster/_identities.tf
+++ b/modules/aks-cluster/_identities.tf
@@ -2,20 +2,17 @@
 #  Cluster Identiies
 # ===================
 
-# AKS
-
-resource "azurerm_user_assigned_identity" "aks_mi" { # Control Plane
-  name                = "${local.name}-mi"
+# Control Plane
+resource "azurerm_user_assigned_identity" "control_plane_mi" {
+  name                = "${local.name}-control-plane-mi"
   resource_group_name = azurerm_resource_group.cluster_rg.name
   location            = azurerm_resource_group.cluster_rg.location
 }
 
-# Kubelet MI
-
-data "azurerm_user_assigned_identity" "kubelet" {
-  name                = "${local.name_suffixed}-cluster-agentpool"
-  resource_group_name = "${local.name_suffixed}-managed-rg"
-  depends_on = [
-    azurerm_kubernetes_cluster.aks
-  ]
+# Kubelet
+resource "azurerm_user_assigned_identity" "kubelet_mi" {
+  name                = "${local.name}-kubelet-mi"
+  resource_group_name = azurerm_resource_group.cluster_rg.name
+  location            = azurerm_resource_group.cluster_rg.location
 }
+

--- a/modules/aks-cluster/_rbac.tf
+++ b/modules/aks-cluster/_rbac.tf
@@ -12,10 +12,17 @@
 # https://www.terraform.io/language/data-sources#data-resource-dependencies
 
 locals {
-  cluster_principal_id          = azurerm_user_assigned_identity.aks_mi.principal_id
-  kubelet_principal_id          = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
-  aks_managed_resource_group_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_kubernetes_cluster.aks.node_resource_group}"
+  cluster_principal_id       = azurerm_user_assigned_identity.control_plane_mi.principal_id
+  kubelet_principal_id       = azurerm_user_assigned_identity.kubelet_mi.principal_id
+  aks_managed_resource_group = azurerm_kubernetes_cluster.aks.node_resource_group
+  # Don't cobble together id just to use a system managed identity
+  # aks_managed_resource_group_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.name_suffixed}-managed-rg" # circular dependency
 }
+
+data "azurerm_resource_group" "aks_managed" {
+  name = local.aks_managed_resource_group
+}
+
 
 # Give Self Admin Access
 # ----------------------
@@ -26,27 +33,58 @@ resource "azurerm_role_assignment" "admin" {
   principal_id         = data.azurerm_client_config.current.object_id # Me
 }
 
-# AAD Pod Identity
+
+# Managed Identity
 # ----------------
 
-resource "azurerm_role_assignment" "kubelet_mi_operator_nodes" {
+# Our Resource Group
+
+resource "azurerm_role_assignment" "control_plane_mi" {
   role_definition_name = "Managed Identity Operator"
-  scope                = local.aks_managed_resource_group_id # data.azurerm_resource_group.aks_managed.id
-  principal_id         = local.kubelet_principal_id
+  scope                = azurerm_resource_group.cluster_rg.id
+  principal_id         = azurerm_user_assigned_identity.control_plane_mi.principal_id
 }
 
-resource "azurerm_role_assignment" "kubelet_vm_contributor" {
-  role_definition_name = "Virtual Machine Contributor"
-  scope                = local.aks_managed_resource_group_id # data.azurerm_resource_group.aks_managed.id
-  principal_id         = local.kubelet_principal_id
-}
-
-# See https://azure.github.io/aad-pod-identity/docs/getting-started/role-assignment/#user-assigned-identities-that-are-not-within-the-node-resource-group
 resource "azurerm_role_assignment" "kubelet_mi_operator" {
   role_definition_name = "Managed Identity Operator"
   scope                = azurerm_resource_group.cluster_rg.id
-  principal_id         = local.kubelet_principal_id
+  principal_id         = azurerm_user_assigned_identity.kubelet_mi.principal_id
 }
+
+# AKS Managed Resource Group
+
+resource "azurerm_role_assignment" "control_plane_mi_nodes" {
+  role_definition_name = "Managed Identity Operator"
+  scope                = data.azurerm_resource_group.aks_managed.id
+  principal_id         = azurerm_user_assigned_identity.control_plane_mi.principal_id
+
+  # circular - wait for managed RG
+  depends_on = [
+    azurerm_kubernetes_cluster.aks
+  ]
+}
+
+resource "azurerm_role_assignment" "kubelet_mi_operator_nodes" {
+  role_definition_name = "Managed Identity Operator"
+  scope                = data.azurerm_resource_group.aks_managed.id
+  principal_id         = azurerm_user_assigned_identity.kubelet_mi.principal_id
+
+  # circular - wait for managed RG
+  depends_on = [
+    azurerm_kubernetes_cluster.aks
+  ]
+}
+
+
+# VMs
+# ---
+
+resource "azurerm_role_assignment" "kubelet_vm_contributor" {
+  role_definition_name = "Virtual Machine Contributor"
+  scope                = data.azurerm_resource_group.aks_managed.id
+  principal_id         = azurerm_user_assigned_identity.kubelet_mi.principal_id
+}
+
 
 # Static IP for LB
 # ----------------
@@ -54,8 +92,9 @@ resource "azurerm_role_assignment" "kubelet_mi_operator" {
 resource "azurerm_role_assignment" "aks_mi_network_contributor" {
   role_definition_name = "Network Contributor"
   scope                = azurerm_resource_group.cluster_rg.id
-  principal_id         = local.cluster_principal_id
+  principal_id         = azurerm_user_assigned_identity.control_plane_mi.principal_id
 }
+
 
 # ACR
 # ---
@@ -63,8 +102,9 @@ resource "azurerm_role_assignment" "aks_mi_network_contributor" {
 resource "azurerm_role_assignment" "acr_assignments" {
   role_definition_name = "AcrPull"
   scope                = azurerm_container_registry.acr.id
-  principal_id         = local.kubelet_principal_id
+  principal_id         = azurerm_user_assigned_identity.kubelet_mi.principal_id
 }
+
 
 # Key Vault
 # ---------
@@ -78,5 +118,5 @@ resource "azurerm_role_assignment" "kv_admin" {
 resource "azurerm_role_assignment" "cluster_kv_kubelet_mi" {
   role_definition_name = "Key Vault Secrets User"
   scope                = azurerm_key_vault.cluster_kv.id
-  principal_id         = local.kubelet_principal_id
+  principal_id         = azurerm_user_assigned_identity.kubelet_mi.principal_id
 }

--- a/modules/aks-cluster/outputs.tf
+++ b/modules/aks-cluster/outputs.tf
@@ -39,8 +39,8 @@ output "summary" {
       }
     }
     managed_identities = {
-      control_plane = azurerm_user_assigned_identity.aks_mi
-      kubelet       = data.azurerm_user_assigned_identity.kubelet
+      control_plane = azurerm_user_assigned_identity.control_plane_mi
+      kubelet       = azurerm_user_assigned_identity.kubelet_mi
     }
     principal_ids = {
       cluster_principal_id = local.cluster_principal_id


### PR DESCRIPTION
## Problem

Every time Terraform ran, all the Role Assignments needed to be re-created although no RBAC configuration change was made.

Plan would show something like this (example code from linked support issues below)

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # azurerm_role_assignment.test must be replaced
-/+ resource "azurerm_role_assignment" "test" {
      ~ id                               = "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/yicm-rg-assignment/providers/Microsoft.Authorization/roleAssignments/4ab771b0-46c2-d7ae-a50f-2416cb45cabb" -> (known after apply)
      ~ name                             = "4ab771b0-46c2-d7ae-a50f-2416cb45cabb" -> (known after apply)
      ~ principal_type                   = "ServicePrincipal" -> (known after apply)
      ~ role_definition_id               = "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635" -> (known after apply)
      ~ scope                            = "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/yicm-rg-assignment" -> "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/yicm-rg-assignment-2" # forces replacement
      + skip_service_principal_aad_check = (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

## Cause

Description from one of the support issues below

> I found a similar issue https://github.com/hashicorp/terraform-provider-azurerm/issues/13152 where role_assignment depends on a data source which then depends on an AKS resource. When AKS resource is updated, data source which depends on it will be read again in apply phase, which is by design according to [Data Resource Dependencies document](https://www.terraform.io/language/data-sources#data-resource-dependencies), and this can be resolved by adding a indirect dependency using a local value. e.g.:

https://github.com/hashicorp/terraform-provider-azurerm/issues/15557
https://github.com/hashicorp/terraform-provider-azurerm/issues/13152

## Solution No. 1 (temporary)

Sorry I squashed the code, so it there's no commit for it.

I applied the workaround described above with string concatenation:

```
locals = {
  aks_managed_resource_group_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.name_suffixed}-managed-rg" # circular dependency
}
```

## Solution No. 2 (permanent)

The circular dependencies arose from a chicken and egg like problem where to follow principle of least privilege (PILP), we want to limit some access scopes to a Resource Group that is owned by the AKS Control Plane. That means we need to wait for it to exist.

The problem was that this security principal was a system managed identity - i.e. lifecycle managed by Azure.

To avoid this altogether I switched to a User Assigned Managed Identity. While it sounds like a more cumbersome solution, I personally think this is cleaner because

- Less likely to have dangling Role Assignments compared to when Azure managed (although arguable some colleagues consider this an Azure "bug". I see ARM and AAD as two separate control planes).
- Managed Identity is a **security mechanism** and I think it's worth making users be more explicit when it comes to security. Too many people think it's magic. It's actually complex under the hood and most people say "It should just work" not aware of the trade-offs they're making.

Anyway, changes

- created explicit user assigned managed identity for the kubelet
- created consistent naming for control plane vs kubelet identities
- figured out the `depends_on` references after some trial and error.